### PR TITLE
Replace resource isntances by Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ In the following table, every path showed in the Path column is meant to be appe
 | UpdateById | PUT | /{uuid} | Updates a resource |
 | UpdateByQuery | PUT | / | Updates a resource that matches query parameters |
 | PatchById | PATCH | /{uuid} | Updates a resource by id using PATCH semantics |
-| ReplaceById | PUT | /{uuid}/replace | Replaces a resource by id, (primary id field (and _id if not the same) are not replaced) |
+| ReplaceById | PUT | /{uuid}/replace | Replaces a resource by id. Primary id field (and _id if not the same) are not replaced |
 | DeleteById | DELETE | /{uuid} | Deletes a resource |
 | DeleteByQuery | DELETE | / | Deletes resources matching filters in the querystring |
 | Count | GET | / | Count resources in collection matching filters in the querysting |

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ In the following table, every path showed in the Path column is meant to be appe
 | UpdateById | PUT | /{uuid} | Updates a resource |
 | UpdateByQuery | PUT | / | Updates a resource that matches query parameters |
 | PatchById | PATCH | /{uuid} | Updates a resource by id using PATCH semantics |
+| ReplaceById | PUT | /{uuid}/replace | Replaces a resource by id, (primary id field (and _id if not the same) are not replaced) |
 | DeleteById | DELETE | /{uuid} | Deletes a resource |
 | DeleteByQuery | DELETE | / | Deletes resources matching filters in the querystring |
 | Count | GET | / | Count resources in collection matching filters in the querysting |
@@ -198,7 +199,8 @@ const router = buildRouter({
     deleteById: true,
     deleteByQuery: true,
     count: true,
-    patchById: true
+    patchById: true,
+    replaceById: true
   }
 })
 // Default resource deletion
@@ -282,6 +284,8 @@ Typically, in `pre` hooks you will want to manually edit requests or do some kin
 - post:deleteByQuery
 - pre:patchById
 - post:patchById
+- pre:replaceById
+- post:replaceById
 - pre:*
 - post:*
 - pre:finalize

--- a/src/controller.js
+++ b/src/controller.js
@@ -20,7 +20,6 @@ class Controller {
    * @param {String} [config.id] The attribute to use as primary key for findById, updateById and deleteById. Defaults to _id.
    * @param {Number} [config.defaultSkipValue] The default skip value to be used in find() queries
    * @param {Number} [config.defaultLimitValue] The default skip value to be used in find() queries
-   *
    */
   constructor (config) {
     this.Model = config.model
@@ -213,6 +212,32 @@ class Controller {
     for (var k in update) {
       instance.set(k, update[k])
     }
+
+    const validationError = instance.validateSync()
+    if (validationError) {
+      throw new Errors.BadRequest(validationError.message)
+    }
+
+    return instance.save()
+  }
+
+  /**
+ *
+ * @param {String | Number} id The id of the resource to update
+ * @param {Object} replacement The replacement object
+ */
+  async replaceById (id, replacement) {
+    const query = {}
+    query[this.id] = id
+    const instance = await this.Model.findOne(query)
+
+    if (instance === null) {
+      throw new Errors.NotFound()
+    }
+    // Primary identifiers cannot be replaced
+    delete replacement['_id']
+    delete replacement[this.id]
+    instance.overwrite(replacement)
 
     const validationError = instance.validateSync()
     if (validationError) {

--- a/src/router.js
+++ b/src/router.js
@@ -39,7 +39,8 @@ const defaultEndpoints = {
   deleteById: true,
   deleteByQuery: true,
   count: true,
-  patchById: true
+  patchById: true,
+  replaceById: true
 }
 
 /**
@@ -116,6 +117,12 @@ function buildRouter (config) {
     return next()
   })
 
+  const replaceByIdMiddleware = asyncMiddleware(async (req, res, next) => {
+    const resource = await config.controller.replaceById(req.params.id, req.body)
+    req.toSend = resource
+    return next()
+  })
+
   const endpoints = {
     count: {
       method: 'get',
@@ -161,6 +168,11 @@ function buildRouter (config) {
       method: 'patch',
       path: '/:id',
       middleware: patchByIdMiddleware
+    },
+    replaceById: {
+      method: 'put',
+      path: '/:id/replace',
+      middleware: replaceByIdMiddleware
     }
 
   }

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -9,6 +9,9 @@ const ctrl = new Controller({
   defaultSkipValue: 0,
   model: CatModel
 })
+// ObjectIDs do not accept any value, to avoid CastErrors
+// we use this string
+const NON_EXISTING_ID = 'nothingtosee'
 
 const cats = [{ name: 'Snowball I' }, { name: 'Snowball II' }, { name: 'Snowball III' }, { name: 'Snowball V' }]
 
@@ -40,13 +43,13 @@ test('Reject invalid resource', async t => {
 
 test('Reject updateById on non existing resource', async t => {
   const err = await t.throwsAsync(async () => {
-    await ctrl.updateById('nothingtosee')
+    await ctrl.updateById(NON_EXISTING_ID)
   })
   t.is(err.name, 'NotFound')
 })
 test('Reject updateOne on non existing resource', async t => {
   const err = await t.throwsAsync(async () => {
-    await ctrl.updateByQuery({ name: 'nothingtosee' })
+    await ctrl.updateByQuery({ name: NON_EXISTING_ID })
   })
   t.is(err.name, 'NotFound')
 })
@@ -65,7 +68,7 @@ test('Reject updateById on invalid data', async t => {
 })
 test('Reject findOne non existing resource', async t => {
   const err = await t.throwsAsync(async () => {
-    await ctrl.findOne({ name: 'nothingtosee' })
+    await ctrl.findOne({ name: NON_EXISTING_ID })
   })
   t.is(err.name, 'NotFound')
 })
@@ -326,7 +329,7 @@ test('Should correctly reject patch operations on non existing resources', async
 
   const patch = [{ op: 'replace', path: '/name', value: null }]
   const err = await t.throwsAsync(async () => {
-    await c.patchById('nothingtosee', patch)
+    await c.patchById(NON_EXISTING_ID, patch)
   })
   t.true(err instanceof Errors.NotFound)
 })
@@ -347,7 +350,7 @@ test('Should correctly reject the invalid JSON Patch format', async t => {
   t.true(err instanceof Errors.BadRequest)
 })
 
-test('Should correclty replace instances of a resource', async t => {
+test('Should correctly replace instances of a resource', async t => {
   const ZebraModel = makeModel('Zebra')
   const c = new Controller({
     name: 'zebras',
@@ -367,4 +370,40 @@ test('Should correclty replace instances of a resource', async t => {
   t.is(String(replaced._id), String(instance._id))
   t.is(replaced.name, replacement.name)
   t.is(replaced.owner, undefined)
+})
+
+test('Should refuse to replace a non existing resource', async t => {
+  const ZebraModel = makeModel('WeirdZebra')
+  const c = new Controller({
+    name: 'zebras',
+    defaultLimitValue: 20,
+    defaultSkipValue: 0,
+    model: ZebraModel
+  })
+  const replacement = {
+    name: 'Zobry',
+    age: 4
+  }
+
+  const err = await t.throwsAsync(c.replaceById(NON_EXISTING_ID, replacement))
+  t.is(err.name, 'NotFound')
+})
+
+test('Should refuse to replace a resource with invalid data', async t => {
+  const ZebraModel = makeModel('RegularZebra')
+  const c = new Controller({
+    name: 'zebras',
+    defaultLimitValue: 20,
+    defaultSkipValue: 0,
+    model: ZebraModel
+  })
+
+  const instance = await c.create({ name: 'Zeebry', age: 2, owner: 'Harry Potter' })
+  const badReplacement = {
+    age: 4
+  }
+
+  const err = await t.throwsAsync(c.replaceById(instance._id, badReplacement))
+
+  t.is(err.name, 'BadRequest')
 })

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -291,11 +291,12 @@ test('Should correctly apply the JSON Patch', async t => {
     model: HorseModel
   })
 
-  const instance = await c.create({ name: 'horse-1' })
-  const patch = [ { op: 'replace', path: '/name', value: 'horse-2' } ]
+  const instance = await c.create({ name: 'horse-1', owner: 'Matt' })
+  const patch = [{ op: 'remove', path: '/owner' }, { op: 'replace', path: '/name', value: 'horse-2' }]
   const updatedInstance = await c.patchById(instance._id, patch)
 
   t.is(updatedInstance.name, 'horse-2')
+  t.is(updatedInstance.owner, undefined)
   t.is(String(updatedInstance._id), String(instance._id))
 })
 
@@ -344,4 +345,26 @@ test('Should correctly reject the invalid JSON Patch format', async t => {
     await c.patchById(instance._id, patch)
   })
   t.true(err instanceof Errors.BadRequest)
+})
+
+test('Should correclty replace instances of a resource', async t => {
+  const ZebraModel = makeModel('Zebra')
+  const c = new Controller({
+    name: 'zebras',
+    defaultLimitValue: 20,
+    defaultSkipValue: 0,
+    model: ZebraModel
+  })
+
+  const instance = await c.create({ name: 'Zeebry', age: 2, owner: 'Harry Potter' })
+  const replacement = {
+    name: 'Zobry',
+    age: 4
+  }
+
+  const replaced = await c.replaceById(instance._id, replacement)
+
+  t.is(String(replaced._id), String(instance._id))
+  t.is(replaced.name, replacement.name)
+  t.is(replaced.owner, undefined)
 })

--- a/test/helpers/mockmodel.helper.js
+++ b/test/helpers/mockmodel.helper.js
@@ -22,6 +22,9 @@ const makeModel = (name) => {
     age: {
       type: Number,
       default: 1
+    },
+    owner: {
+      type: String
     }
   }, { strict: true })
 

--- a/test/router.spec.js
+++ b/test/router.spec.js
@@ -204,7 +204,9 @@ test('Should run all hooks', async t => {
     postCreate: sinon.spy(),
     preFinalize: sinon.spy(),
     prePatch: sinon.spy(),
-    postPatch: sinon.spy()
+    postPatch: sinon.spy(),
+    preReplaceById: sinon.spy(),
+    postReplaceById: sinon.spy()
   }
 
   ctrl.registerHook('pre:create', (req, res, next) => {
@@ -260,6 +262,16 @@ test('Should run all hooks', async t => {
     next()
   })
 
+  ctrl.registerHook('pre:replaceById', (req, res, next) => {
+    spies.preReplaceById()
+    next()
+  })
+
+  ctrl.registerHook('post:replaceById', (req, res, next) => {
+    spies.postReplaceById()
+    next()
+  })
+
   const _router = router({
     controller: ctrl
   })
@@ -298,6 +310,12 @@ test('Should run all hooks', async t => {
     .send([{ op: 'replace', path: '/name', value: 'Doggo the patched eye' }])
     .set('Accept', 'application/json')
 
+  // test create hooks
+  await request(t.context.app)
+    .put(`/${doggo._id}/replace`)
+    .send({ name: 'Doggerino the calm' })
+    .set('Accept', 'application/json')
+
   // Test deleteByQuery
   await request(t.context.app)
     .delete('/')
@@ -313,4 +331,6 @@ test('Should run all hooks', async t => {
   t.true(spies.preFinalize.called)
   t.true(spies.prePatch.called)
   t.true(spies.postPatch.called)
+  t.true(spies.preReplaceById.called)
+  t.true(spies.postReplaceById.called)
 })


### PR DESCRIPTION
### Motivation

The default `PUT /resource/:id` endpoint will not replace the resource, instead it will apply an update using the `$set` MongoDB operator. There are cases in which this behaviour is not enough, for example when we need to remove an attribute from a resource instance.

Of course using a PATCH request would also allow to remove fields from a resource instance, but in some cases it's impractical since the client would need to compute a diff of two states.

### Description

This PR adds a new endpoint: `PUT /resource/:id/replace`, which offers a PUT endpoint as intended in the REST specification. 

### Limitations
This endpoint will **not** replace the `_id` key otherwise MongoDB would create another document. Also, if the resource specifies an id field different from `_id`, that field would also be not modified by this method.