### PR TITLE
fix: updateByQuery should update multiple matching documents

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -177,22 +177,20 @@ class Controller {
   * @return {Promise}
   */
   async updateByQuery (query, update) {
-    const instance = await this.Model.findOne(query)
+    const instances = await this.Model.find(query)
 
-    if (instance === null) {
-      throw new Errors.NotFound()
+    for (const instance of instances) {
+      for (var k in update) {
+        instance.set(k, update[k])
+      }
+
+      const validationError = instance.validateSync()
+      if (validationError) {
+        throw new Errors.BadRequest(validationError.message)
+      }
     }
 
-    for (var k in update) {
-      instance.set(k, update[k])
-    }
-
-    const validationError = instance.validateSync()
-    if (validationError) {
-      throw new Errors.BadRequest(validationError.message)
-    }
-
-    return instance.save()
+    return this.Model.updateMany(query, { $set: update })
   }
 
   /**

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -47,13 +47,7 @@ test('Reject updateById on non existing resource', async t => {
   })
   t.is(err.name, 'NotFound')
 })
-test('Reject updateOne on non existing resource', async t => {
-  const err = await t.throwsAsync(async () => {
-    await ctrl.updateByQuery({ name: NON_EXISTING_ID })
-  })
-  t.is(err.name, 'NotFound')
-})
-test('Reject updateOne on invalid data', async t => {
+test('Reject updateByQuery on invalid data', async t => {
   const err = await t.throwsAsync(async () => {
     await ctrl.updateByQuery({ name: 'Snowball I' }, { age: ['a', 'b', null] })
   })
@@ -154,8 +148,11 @@ test('Find one resource', async t => {
   t.is(cat.name, 'Snowball I')
 })
 
-test('Update one resource', async t => {
-  const cat = await ctrl.updateByQuery({ name: 'Snowball III' }, { name: 'Snowball III+' })
+test('Update one resource with updateByQuery', async t => {
+  let cat = await ctrl.findOne({ name: 'Snowball III' })
+  const catId = cat._id
+  await ctrl.updateByQuery({ name: 'Snowball III' }, { name: 'Snowball III+' })
+  cat = await ctrl.findOne({ _id: catId })
   t.is(cat.name, 'Snowball III+')
 })
 


### PR DESCRIPTION
update by query was NOT doint what it should. The method should take a query and an update object and apply the update object to each resource matching the query